### PR TITLE
Prevents Panel From Creating Alert While Reloading/Closing Page

### DIFF
--- a/src/atlas3.js
+++ b/src/atlas3.js
@@ -532,6 +532,7 @@ export class Atlas3 extends MetricsPanelCtrl {
         });
 
         function render() {
+            window.onbeforeunload = null;
             if (!ctrl.recentData){
                 return;
             }

--- a/src/atlas3.js
+++ b/src/atlas3.js
@@ -41,6 +41,7 @@ const panelDefaults = {
     twin_tubes: false,
     arrows: false,
     weather_tile: false,
+    static_node_tooltip: false,
     nodeFillColor: "rgb(200,200,200)",
     downLinkColor: "rgb(200,200,200)",
     color: {
@@ -626,7 +627,8 @@ export class Atlas3 extends MetricsPanelCtrl {
                         twin_tubes: ctrl.panel.twin_tubes,
                         mapSource: ctrl.panel.mapSrc[j],
                         endpointColor : ctrl.panel.nodeFillColor,
-                        node_content: node_content
+                        node_content: node_content,
+                        static_node_tooltip: ctrl.panel.static_node_tooltip
                     });
 
                     if(ctrl.panel.mapSrc[j] === null || ctrl.panel.mapSrc[j] === undefined || ctrl.panel.mapSrc[j] === "") {
@@ -665,7 +667,8 @@ export class Atlas3 extends MetricsPanelCtrl {
                     zoom: zoom,
                     twin_tubes: ctrl.panel.twin_tubes,
                     tooltip: ctrl.panel.tooltip,
-                    weather_tile: ctrl.panel.weather_tile
+                    weather_tile: ctrl.panel.weather_tile,
+                    node_content: node_content
                 });
                 ctrl.map = map;
             } else {
@@ -729,6 +732,7 @@ export class Atlas3 extends MetricsPanelCtrl {
                     lineWidth: ctrl.panel.size[i],
                     mapSource: ctrl.panel.mapSrc[i],
                     endpointColor : ctrl.panel.nodeFillColor,
+                    static_node_tooltip: ctrl.panel.static_node_tooltip 
                 });
                 ctrl.layer_ids.push(networkLayer.layerId());
                 ctrl.panel.layers.push(networkLayer);

--- a/src/css/NetworkLayer.css
+++ b/src/css/NetworkLayer.css
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 .atlas-info-div {
-    background-color: #fcfcfa;
+    /* background-color: #fcfcfa; */
     color: black;
     display: block;
     min-width: 100px;
     min-height: 10px;
-    border-width: 1px;
+    /* border-width: 1px;
     border-style: solid;
     border-radius: 8px;
-    background: white;
+    background: white; */
     border-color: #797874;
     padding: 1px 5px 1px 5px;  
     z-index: 99999;

--- a/src/js/map/LeafletMap.js
+++ b/src/js/map/LeafletMap.js
@@ -405,7 +405,9 @@ var LeafletMap = function(params) {
             max: layer.max,
             min: layer.min,
             offsets: [-360,0,360],
-	        lineThickness: layer.lineWidth
+            lineThickness: layer.lineWidth,
+            node_content: layer.node_content || params.node_content,
+            static_node_tooltip: layer.static_node_tooltip
         };
         
         var network_layer;

--- a/src/js/map/NetworkLayer.js
+++ b/src/js/map/NetworkLayer.js
@@ -538,10 +538,10 @@ var NetworkLayer = function(params){
      * @chainable
      */
     layer.showEndpointInfo = function(params){
+        if (params.static_tooltip) return;
         var endpoint = params.endpoint; 
         var div_pos = params.pos;
         if(!tooltip.show) return;
-
         var endpointStr = _createEndpointInfoMarkup(endpoint); 
         //if it's pinned select the link
         if(params.pin){

--- a/src/js/map/SingleTubeLayer.js
+++ b/src/js/map/SingleTubeLayer.js
@@ -53,6 +53,7 @@ var SingleTubeLayer = function(params){
     params.lineOpacity = params.lineOpacity || 1;
     params.endpointOpacity = params.endpointOpacity || 1;
     params.endpointColor = params.endpointColor || '#ddd';
+    console.log(params)
     var layer = NetworkLayer(params);
     if(!params.svg){
         console.error('Must pass in a svg element to render into');
@@ -130,7 +131,8 @@ var SingleTubeLayer = function(params){
                 pos: {
                     page_x: d.event.pageX,
                     page_y: d.event.pageY
-                }
+                },
+                static_tooltip: params.static_node_tooltip
             });
             d3.select(d.event.target).style("cursor", "pointer");
         },
@@ -368,20 +370,26 @@ var SingleTubeLayer = function(params){
             })
             .attr("r", ddr+"px");
         
-        // endpoints.selectAll('text').remove()
-
-        // endpoints
-        //     .append('text')
-        //     .html(function(d) {
-        //         return d.name
-        //     })
-        //     .attr("x", function (d) {
-        //         let dimension = this.getBoundingClientRect()
-        //         return layer.latLngToXy([d.lat, d.lon])[0] - (dimension.width/2);
-        //     })
-        //     .attr("y", function (d) {
-        //         return layer.latLngToXy([d.lat, d.lon])[1] - (ddr*2);
-        //     })
+        if (params.static_node_tooltip) {
+            endpoints.selectAll('foreignObject').remove()
+            endpoints
+                .append('foreignObject')
+                .style('overflow', 'visible')
+                .html(function(d) {
+                    let strHTML = params.node_content.replace('$name', d.name)
+                    return strHTML
+                })
+                .attr("x", function (d) {
+                    let offset = this.getElementsByClassName('atlas-node-tooltip')[0].offsetWidth/2
+                    return layer.latLngToXy([d.lat, d.lon])[0] - offset;
+                })
+                .attr("y", function (d) {
+                    let offset = this.getElementsByClassName('atlas-node-tooltip')[0].offsetHeight
+                    let yOffset = this.querySelector('.atlas-node-tooltip').getAttribute('yOffset')
+                    return layer.latLngToXy([d.lat, d.lon])[1] - offset - yOffset;
+                })
+        }
+        
         
         // Draw Pointed Shapes
         endpoints.select(".popHighlight.triangle, .popHighlight.square, .popHighlight.diamond")

--- a/src/js/map/TwinTubeLayer.js
+++ b/src/js/map/TwinTubeLayer.js
@@ -141,7 +141,8 @@ var TwinTubeLayer = function(params){
                 pos: {
                     page_x: d.event.pageX,
                     page_y: d.event.pageY
-                }
+                },
+                static_tooltip: params.static_node_tooltip
             });
             d3.select(d.event.target).style("cursor", "pointer");
         },
@@ -618,6 +619,26 @@ var TwinTubeLayer = function(params){
                 return layer.latLngToXy([d.lat, d.lon])[1];
             })
             .attr("r", ddr+"px");
+
+            if (params.static_node_tooltip) {
+                endpoints.selectAll('foreignObject').remove()
+                endpoints
+                    .append('foreignObject')
+                    .style('overflow', 'visible')
+                    .html(function(d) {
+                        let strHTML = params.node_content.replace('$name', d.name)
+                        return strHTML
+                    })
+                    .attr("x", function (d) {
+                        let offset = this.getElementsByClassName('atlas-node-tooltip')[0].offsetWidth/2
+                        return layer.latLngToXy([d.lat, d.lon])[0] - offset;
+                    })
+                    .attr("y", function (d) {
+                        let offset = this.getElementsByClassName('atlas-node-tooltip')[0].offsetHeight
+                        let yOffset = this.querySelector('.atlas-node-tooltip').getAttribute('yOffset')
+                        return layer.latLngToXy([d.lat, d.lon])[1] - offset - yOffset;
+                    })
+            }
 
         // Draw Pointed Shapes
         endpoints.select(".popHighlight.triangle, .popHighlight.square, .popHighlight.diamond")

--- a/src/partials/display_editor.html
+++ b/src/partials/display_editor.html
@@ -152,8 +152,12 @@
         </div>
     </div>
 
+    <gf-form-switch class="gf-form" label-class="width-6"
+        label="Static Tooltip" checked="ctrl.panel.static_node_tooltip" on-change="ctrl.render()">
+    </gf-form-switch>
+
     <div ng-if="ctrl.panel.tooltip.show && ctrl.panel.tooltip.showNodeHover" class="section gf-form-group">  
-        <h5 class="section-heading">Custom Node Hover Box</h5>  
+        <h5 class="section-heading">Custom Node Info Box</h5>  
         <div class="gf-from-inline">
             <div class="gf-form gf-form--grow">
                 <textarea class="gf-form-input ng-pristine ng-valid ng-not-empty ng-touched" ng-model="ctrl.panel.tooltip.node_content" rows="8" cols="50" style="width:100%" give-focus="true" ng-change="ctrl.render()" ng-model-onblur=""></textarea>


### PR DESCRIPTION
Fixed an issue that caused the Metrics Panel to instantiate a popup when a user tried to leave a page.