### PR TITLE
Fix build for more recent releases of Node.js

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,7 @@
 ## Development
 
-This project requires Node v6.xx.x and npm v3.10.10
+### Node.js 6.x to 11.15
+This project was originally conceived with Node v6.xx.x and npm v3.10.10.
 
  * Clone this repository
     ```git clone repo_url```
@@ -11,4 +12,19 @@ This project requires Node v6.xx.x and npm v3.10.10
  * Build the plugin
     `npm run build` or `gulp` should create a `dist` folder that contains the transpiled code for the browser
   * Make sure to build the plugin whenever there's a code change
-  
+
+### Node.js >11.15
+When using Node.js >11.15, these commands might work already.
+```
+# Install dependencies.
+npx yarn install
+
+# Run build.
+npx yarn build
+```
+
+When Yarn is not installed (YMMV), this command might help:
+```
+# Install yarn globally.
+npm install yarn -g
+```

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "lodash": "~4.17.5",
     "moment": "^2.12.0",
     "topojson": "^1.6.19"
+  },
+  "resolutions": {
+    "graceful-fs": "^4.2.4"
   }
 }


### PR DESCRIPTION
Hi there,

this adds compatibility for Node.js >11.15, see #101, #102 and #109.

With kind regards,
Andreas.


### Build instructions
When using Node.js >11.15, these commands might work already.
```
# Install dependencies.
npx yarn install

# Run build.
npx yarn build
```

When Yarn is not installed (YMMV), this command might help:
```
# Install yarn globally.
npm install yarn -g
```
